### PR TITLE
chore(API): Upgrade API to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 WISE development uses [Docker](https://www.docker.com/). Using Docker simplifies and standardizes the development environment so that developers can quickly and easily start developing WISE.
 
 ## Setup
-1. Install Docker from [here](https://www.docker.com/products/docker-desktop).
+1. Install Docker from [here](https://www.docker.com/products/docker-desktop).  In the Docker preferences, set the RAM to at least 5GB.
 2. In the same folder, checkout [WISE-Docker-Dev (this project)](https://github.com/WISE-Community/WISE-Docker-Dev), [WISE-API](https://github.com/WISE-Community/WISE-API), and [WISE-Client](https://github.com/WISE-Community/WISE-Client).
 ```
 $ git clone https://github.com/WISE-Community/WISE-Docker-Dev
@@ -15,13 +15,20 @@ WISE-Docker-Dev
 WISE-API
 WISE-Client
 ```
-3. Run ```docker-compose up``` in the WISE-Docker-Dev directory
+3. Run ```docker compose up``` in the WISE-Docker-Dev directory
 ```
 $ cd WISE-Docker-Dev
-WISE-Docker-Dev $ docker-compose up
+WISE-Docker-Dev $ docker compose up
 ```
-4. Wait for everything to download, compile, and start. This can take a while depending on your connection speed.
-5. When everything is done, WISE will be running at http://localhost:81. Go there with your browser to load the WISE homepage.
+4. Wait for everything to download, compile, and start. This can take a while depending on your computer and connection speeds. When you see this in the output, all of the application has started:
+```
+...
+wise-client  | ** Angular Live Development Server is listening on 0.0.0.0:4200, open your browser on http://localhost:4200/ **
+wise-client  | 
+wise-client  | 
+wise-client  | ✔ Compiled successfully.
+```
+5. When you see the above output in your log output, WISE will be running at http://localhost:81. Go there with your browser to load the WISE homepage.
 6. Log in with admin/pass, or previewuser/wise.
 
 Any changes that you make to the source code will be automatically compiled and reloaded in the browser. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     container_name: wise-redis
 
   wise-mysql:
+    platform: linux/x86_64
     image: mysql:8
     container_name: wise-mysql
     environment:
@@ -18,7 +19,7 @@ services:
       - './data:/var/lib/mysql'
 
   wise-api:
-    image: wiseberkeley/wise-api-dev:v1
+    image: wiseberkeley/wise-api-dev:v2
     container_name: wise-api
     expose:
       - '5005'


### PR DESCRIPTION
- Also added platform: linux/x86_64 to mysql service to work with Apple M1 processors.

## Test
- Run ```docker compose up``` this should pull and use the new wise-api-dev:v2 image from [here](https://hub.docker.com/layers/179554151/wiseberkeley/wise-api-dev/v2/images/sha256-d93c5049ae5f83510e6ed3dc7877a40b77d4f21f84b70e5a5679306cfeed0663?context=repo)
- Make sure that you can develop API as before. Making changes should start the server.

Closes #3 