### PR TITLE
build(Client and API): Change development services to use latest images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - './data:/var/lib/mysql'
 
   wise-api:
-    image: wiseberkeley/wise-api-dev:v2
+    image: wiseberkeley/wise-api-dev:latest
     container_name: wise-api
     expose:
       - '5005'
@@ -34,7 +34,7 @@ services:
     command: mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:5005" -Dspring-boot.run.profiles=dockerdev
 
   wise-client:
-    image: wiseberkeley/wise-client-dev:v6
+    image: wiseberkeley/wise-client-dev:latest
     container_name: wise-client
     depends_on:
       - wise-api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     command: mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:5005" -Dspring-boot.run.profiles=dockerdev
 
   wise-client:
-    image: wiseberkeley/wise-client-dev:v5
+    image: wiseberkeley/wise-client-dev:v6
     container_name: wise-client
     depends_on:
       - wise-api


### PR DESCRIPTION
## Test
- Run ```docker compose up``` this should pull and use the latest wise-client-dev image (currently v7) and wise-api-dev image (currently v2)
- Make sure that you can develop client and api as before. Making changes should start the servers.

Closes #5 