### PR TITLE
feat(UnitLibrary): Make curriculum proxy into a regex

### DIFF
--- a/nginx/conf.d/wise.conf
+++ b/nginx/conf.d/wise.conf
@@ -92,7 +92,8 @@ proxy_set_header X-Forwarded-Host $server_name;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
-    location ~ /curriculum/(.*) {
+
+    location ~ /curriculum/(?!personal)(?!public)(.*) {
 proxy_pass $w_api;
 proxy_set_header Host $host:$server_port;
 proxy_set_header X-Forwarded-Host $server_name;

--- a/nginx/conf.d/wise.conf
+++ b/nginx/conf.d/wise.conf
@@ -92,7 +92,7 @@ proxy_set_header X-Forwarded-Host $server_name;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
-    location /curriculum {
+    location ~ /curriculum/(.*) {
 proxy_pass $w_api;
 proxy_set_header Host $host:$server_port;
 proxy_set_header X-Forwarded-Host $server_name;


### PR DESCRIPTION
This is to accommodate the new curriculum route in wise-client.
Adds support for /personal and /public in /curriculum route.